### PR TITLE
Extract media

### DIFF
--- a/ph_py/helpers.py
+++ b/ph_py/helpers.py
@@ -79,7 +79,8 @@ def parse_posts(posts):
             posts["comments"],
             posts["votes"],
             posts["related_links"],
-            posts["install_links"]
+            posts["install_links"],
+            posts["media"]
         )
 
 


### PR DESCRIPTION
Modified parse_posts helper to extract media info when requesting details about a specific post (will be null when a list of post is requested)